### PR TITLE
fix: cross-runtime consistency fixes

### DIFF
--- a/unicorn_contracts/src/contracts_service/contractEventHandler.ts
+++ b/unicorn_contracts/src/contracts_service/contractEventHandler.ts
@@ -165,7 +165,7 @@ class ContractEventHandlerFunction implements LambdaInterface {
     const ddbUpdateCommandInput: UpdateItemCommandInput = {
       TableName: DDB_TABLE,
       Key: { property_id: { S: dbEntry.property_id } },
-      UpdateExpression: 'set contract_status = :t, modified_date = :m',
+      UpdateExpression: 'set contract_status = :t, contract_last_modified_on = :m',
       ConditionExpression:
         'attribute_exists(property_id) AND contract_status = :DRAFT',
       ExpressionAttributeValues: {

--- a/unicorn_web/src/publication_manager_service/publicationEvaluationEventHandler.ts
+++ b/unicorn_web/src/publication_manager_service/publicationEvaluationEventHandler.ts
@@ -43,7 +43,7 @@ class PublicationEvaluationEventHandler implements LambdaInterface {
       tracer.addErrorAsMetadata(error as Error);
       logger.error(`Error during DDB UPDATE: ${JSON.stringify(error)}`);
     }
-    metrics.addMetric('ContractUpdated', MetricUnit.Count, 1);
+    metrics.addMetric('PropertiesApproved', MetricUnit.Count, 1);
   }
 
   /**
@@ -63,6 +63,11 @@ class PublicationEvaluationEventHandler implements LambdaInterface {
       `Updating status: ${propertyEvaluation.evaluationResult} for ${propertyEvaluation.propertyId}`
     );
     const propertyId = propertyEvaluation.propertyId;
+    const validResults = ['APPROVED', 'DECLINED'];
+    if (!validResults.includes(propertyEvaluation.evaluationResult?.toUpperCase())) {
+      logger.warn(`Unknown evaluationResult '${propertyEvaluation.evaluationResult}'; skipping DynamoDB update`);
+      return;
+    }
     const { PK, SK } = this.getDynamoDBKeys(propertyId);
     const updateItemCommandInput: UpdateItemCommandInput = {
       Key: { PK: { S: PK }, SK: { S: SK } },

--- a/unicorn_web/src/publication_manager_service/requestApprovalFunction.ts
+++ b/unicorn_web/src/publication_manager_service/requestApprovalFunction.ts
@@ -140,7 +140,7 @@ class RequestApprovalFunction implements LambdaInterface {
         description: property.description,
       };
 
-      await this.firePropertyEvent(eventDetail, 'unicorn-web');
+      await this.firePropertyEvent(eventDetail);
     } catch (error) {
       tracer.addErrorAsMetadata(error as Error);
       logger.error(`${error}`);
@@ -181,8 +181,7 @@ class RequestApprovalFunction implements LambdaInterface {
    * @param source
    */
   private async firePropertyEvent(
-    eventDetail: PropertyDetailsEvent,
-    source: string
+    eventDetail: PropertyDetailsEvent
   ): Promise<void> {
     const propertyId = eventDetail.property_id;
 
@@ -190,7 +189,7 @@ class RequestApprovalFunction implements LambdaInterface {
     const eventsPutEventsCommandInputEntry: PutEventsRequestEntry = {
       EventBusName: EVENT_BUS,
       Time: new Date(),
-      Source: source,
+      Source: process.env.SERVICE_NAMESPACE ?? 'unicorn-web',
       DetailType: 'PublicationApprovalRequested',
       Detail: JSON.stringify(eventDetail),
     };

--- a/unicorn_web/src/search_service/propertySearchFunction.ts
+++ b/unicorn_web/src/search_service/propertySearchFunction.ts
@@ -205,11 +205,11 @@ class PropertySearchFunction implements LambdaInterface {
     const city = event.pathParameters?.city;
     const street = event.pathParameters?.street;
     const number = event.pathParameters?.number;
-    console.log(`Country: ${country}`);
-    console.log(`City: ${city}`);
-    console.log(`street: ${street}`);
-    console.log(`number: ${number}`);
-    console.log(`PROJECT PROPS: ${PROJECTION_PROPERTIES}`);
+    logger.info(`Country: ${country}`);
+    logger.info(`City: ${city}`);
+    logger.info(`street: ${street}`);
+    logger.info(`number: ${number}`);
+    logger.info(`PROJECT PROPS: ${PROJECTION_PROPERTIES}`);
 
     logger.info(
       `Get property details for: country = ${country}; city = ${city}; street = ${street}; number = ${number}`


### PR DESCRIPTION
**Issue number:** #288

## Summary

### Changes

Fixes to align the TypeScript runtime with Java, Python, and .NET for functional equivalence and cross-runtime consistency.

**Contracts Service (`unicorn_contracts`)**
- `contractEventHandler.ts` — `updateContract`: changed `UpdateExpression` from `'set contract_status = :t, modified_date = :m'` to `'set contract_status = :t, contract_last_modified_on = :m'` — fixes a bug where updates wrote to a non-existent `modified_date` attribute

**Web Service (`unicorn_web`)**
- `requestApprovalFunction.ts`: replaced hardcoded `'unicorn-web'` EventBridge source with `process.env.SERVICE_NAMESPACE ?? 'unicorn-web'`
- `publicationEvaluationEventHandler.ts`: changed `metrics.addMetric('ContractUpdated', ...)` to `metrics.addMetric('PropertiesApproved', ...)` — `ContractUpdated` was incorrect for this handler
- `publicationEvaluationEventHandler.ts`: added validation guard — only processes `'APPROVED'` or `'DECLINED'` evaluation results; logs a warning and returns for any other value
- `propertySearchFunction.ts`: replaced all `console.log(...)` calls in the `propertyDetails` method with `logger.info(...)` to route all output through the Powertools structured logger

### User experience

**Before:** `updateContract` silently wrote a `modified_date` attribute that was never read, leaving `contract_last_modified_on` unchanged on update. The publication evaluation handler emitted a `ContractUpdated` metric (wrong handler) and processed all evaluation result values without validation. Property search logs bypassed the structured logger.

**After:** `updateContract` correctly updates `contract_last_modified_on` consistent with all other runtimes. The publication evaluation handler emits `PropertiesApproved` and validates result values before writing to DynamoDB. All log output in `propertyDetails` is structured JSON via the Powertools logger.

## Checklist

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-samples/aws-serverless-developer-experience-workshop-typescript/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.